### PR TITLE
README: Fix typo in code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ struct Value* interpretCall(struct Expr *body,
 struct Value* call(struct Func *func,
                    struct Value* val) {
   if (func->jitCode) {
-    struct Value* (*f)(struct Value*) = jitCode;
+    struct Value* (*f)(struct Value*) = func->jitCode;
     return f(val);
   } else {
     recordJitCandidate(func);


### PR DESCRIPTION
This commit just adds a missing `func->` from the C code snippet example.